### PR TITLE
Adding site title's back to the config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 name: John Smith
 description: "Nifty little description"
 url: ""
+title: ""
 
 
 # Delete the lines you don't need


### PR DESCRIPTION
Site.title was missing from the Config file. This proposed change adds it back. 

The index file still has code that references site.title in between the <title></title> tags, but it would just show the URL by default because "title" wasn't specified anywhere.